### PR TITLE
Add handlers for identity providers, protocols, and mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Seeding currently only supports creating or updating of entities (upserts).
     - role-assignments
     - users
     - roles
+    - identity_providers
+        - protocols (nested under identity provider)
+    - federation_mappings
     - swift 
         - account
         - containers
@@ -168,3 +171,28 @@ Example seed spec of a keystone seed to be deployed via helm:
             description: Administrator Project
         - name: service
             description: Services Project
+
+Example seed spec for SAML federation (identity providers and mappings).
+The ``rules`` field is an opaque JSON string following the Keystone federation
+mapping API format (see https://docs.openstack.org/keystone/latest/admin/federation/mapping_combinations.html).
+It is passed through to the Keystone API as-is and must not be written as YAML:
+
+    apiVersion: "seeder.cloud.sap/v1"
+    kind: "CcloudSeed"
+    metadata:
+      name: saml-federation-mandant-a
+    spec:
+      openstack:
+        federation_mappings:
+        - id: mandant-a-mapping
+          schema_version: "2.0"
+          rules: '[{"local": [{"user": {"name": "{0}", "domain": {"name": "mandant-a"}}}], "remote": [{"type": "REMOTE_USER"}]}]'
+        identity_providers:
+        - id: mandant-a
+          description: "SAML IdP for tenant mandant-a"
+          enabled: true
+          remote_ids:
+          - https://idp.mandant-a.example.com/saml2/metadata
+          protocols:
+          - id: saml2
+            mapping_id: mandant-a-mapping

--- a/charts/templates/config.yaml
+++ b/charts/templates/config.yaml
@@ -6,7 +6,7 @@ data:
   config.ini: |
     [operator]
     version = 1.0
-    handlers = domains,groups,projects.projects,role_assignments,projects.networks,projects.subnet_pools,projects.address_scopes,projects.network_quotas
+    handlers = domains,groups,projects.projects,role_assignments,projects.networks,projects.subnet_pools,projects.address_scopes,projects.network_quotas,identity_providers,federation_mappings
     [crd_names]
     version = v1
     group = seeder.cloud.sap

--- a/etc/config.ini
+++ b/etc/config.ini
@@ -1,5 +1,6 @@
 [operator]
 version = 1.0
+handlers = domains,groups,projects.projects,role_assignments,projects.networks,projects.subnet_pools,projects.address_scopes,projects.network_quotas,identity_providers,federation_mappings
 [crd_names]
 version = v1
 group = seeder.cloud.sap

--- a/seeder_ccloud/handlers/federation_mappings.py
+++ b/seeder_ccloud/handlers/federation_mappings.py
@@ -1,0 +1,116 @@
+"""
+ Copyright 2025 SAP SE
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+     http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import json, logging, kopf, time
+from datetime import timedelta, datetime
+from deepdiff import DeepDiff
+from seeder_ccloud.openstack.openstack_helper import OpenstackHelper
+from seeder_ccloud import utils
+
+config = utils.Config()
+
+
+@kopf.on.validate(config.crd_info['plural'], annotations={'operatorVersion': config.operator_version}, field='spec.openstack.federation_mappings')
+def validate_federation_mappings(spec, dryrun, **_):
+    mappings = spec.get('federation_mappings', [])
+    for mapping in mappings:
+        if 'id' not in mapping or not mapping['id']:
+            raise kopf.AdmissionError("Federation mapping must have an id.")
+        if 'rules' not in mapping or not mapping['rules']:
+            raise kopf.AdmissionError("Federation mapping must have rules.")
+        rules = mapping['rules']
+        if isinstance(rules, str):
+            try:
+                parsed = json.loads(rules)
+                if not isinstance(parsed, list):
+                    raise kopf.AdmissionError("Federation mapping rules must be a JSON array.")
+            except json.JSONDecodeError as e:
+                raise kopf.AdmissionError("Federation mapping rules must be valid JSON: %s" % e)
+
+
+@kopf.on.update(config.crd_info['plural'], annotations={'operatorVersion': config.operator_version}, field='spec.openstack.federation_mappings')
+@kopf.on.create(config.crd_info['plural'], annotations={'operatorVersion': config.operator_version}, field='spec.openstack.federation_mappings')
+def seed_federation_mappings_handler(memo: kopf.Memo, patch: kopf.Patch, new, old, name, annotations, **_):
+    logging.info('seeding {} federation_mappings'.format(name))
+    if not config.is_dependency_successful(annotations):
+        raise kopf.TemporaryError('error seeding {}: {}'.format(name, 'dependencies error'), delay=30)
+
+    try:
+        starttime = time.perf_counter()
+        changed = utils.get_changed_seeds(old, new)
+        diffs = FederationMappings(memo['args'], memo['dry_run']).seed(changed)
+        duration = timedelta(seconds=time.perf_counter()-starttime)
+        utils.setStatusFields('federation_mappings', patch, 'seeded', duration=duration, diffs=diffs)
+    except Exception as error:
+        utils.setStatusFields('federation_mappings', patch, 'error', 0, latest_error=str(error))
+        raise kopf.TemporaryError('error seeding {}: {}'.format(name, error), delay=30)
+    finally:
+        patch.status['latest_reconcile'] = datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+class FederationMappings():
+    def __init__(self, args, dry_run=False):
+        self.dry_run = dry_run
+        self.args = args
+        self.openstack = OpenstackHelper(args)
+        self.diffs = {}
+
+    def seed(self, federation_mappings):
+        logging.info('seeding federation mappings')
+        for mapping in federation_mappings:
+            self._seed_mapping(mapping)
+        return self.diffs
+
+    @staticmethod
+    def _parse_rules(rules):
+        """Parse mapping rules from JSON string to Python list.
+
+        Mapping rules are always stored and transmitted as a JSON string.
+        They are only parsed to a Python list at the point of calling the
+        Keystone API (which expects a Python list).
+        """
+        if isinstance(rules, str):
+            return json.loads(rules)
+        return rules
+
+    def _seed_mapping(self, mapping):
+        """Seed a Keystone federation mapping."""
+        mapping_id = mapping['id']
+        rules = self._parse_rules(mapping['rules'])
+        schema_version = mapping.get('schema_version', '2.0')
+        logging.debug("seeding federation mapping %s" % mapping_id)
+
+        keystone = self.openstack.get_keystoneclient()
+
+        try:
+            resource = keystone.federation.mappings.get(mapping_id)
+            # Mapping exists, check if rules or schema_version changed
+            existing_rules = getattr(resource, 'rules', [])
+            existing_sv = getattr(resource, 'schema_version', '')
+            diff = DeepDiff(existing_rules, rules, threshold_to_diff_deeper=0)
+            if diff or existing_sv != schema_version:
+                logging.info("update federation mapping '%s': %s" % (mapping_id, diff))
+                self.diffs[mapping_id] = str(diff)
+                if not self.dry_run:
+                    keystone.federation.mappings.update(
+                        mapping_id, rules=rules, schema_version=schema_version)
+        except Exception:
+            # Mapping does not exist, create it
+            logging.info("create federation mapping '%s'" % mapping_id)
+            self.diffs[mapping_id] = 'created'
+            if not self.dry_run:
+                keystone.federation.mappings.create(
+                    mapping_id, rules=rules, schema_version=schema_version)

--- a/seeder_ccloud/handlers/identity_providers.py
+++ b/seeder_ccloud/handlers/identity_providers.py
@@ -1,0 +1,135 @@
+"""
+ Copyright 2025 SAP SE
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+     http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import logging, kopf, time
+from datetime import timedelta, datetime
+from deepdiff import DeepDiff
+from seeder_ccloud.openstack.openstack_helper import OpenstackHelper
+from seeder_ccloud import utils
+
+config = utils.Config()
+
+
+@kopf.on.validate(config.crd_info['plural'], annotations={'operatorVersion': config.operator_version}, field='spec.openstack.identity_providers')
+def validate_identity_providers(spec, dryrun, **_):
+    identity_providers = spec.get('identity_providers', [])
+    for idp in identity_providers:
+        if 'id' not in idp or not idp['id']:
+            raise kopf.AdmissionError("Identity provider must have an id.")
+        protocols = idp.get('protocols', [])
+        for protocol in protocols:
+            if 'id' not in protocol or not protocol['id']:
+                raise kopf.AdmissionError("Protocol must have an id.")
+            if 'mapping_id' not in protocol or not protocol['mapping_id']:
+                raise kopf.AdmissionError("Protocol must have a mapping_id.")
+
+
+@kopf.on.update(config.crd_info['plural'], annotations={'operatorVersion': config.operator_version}, field='spec.openstack.identity_providers')
+@kopf.on.create(config.crd_info['plural'], annotations={'operatorVersion': config.operator_version}, field='spec.openstack.identity_providers')
+def seed_identity_providers_handler(memo: kopf.Memo, patch: kopf.Patch, new, old, name, annotations, **_):
+    logging.info('seeding {} identity_providers'.format(name))
+    if not config.is_dependency_successful(annotations):
+        raise kopf.TemporaryError('error seeding {}: {}'.format(name, 'dependencies error'), delay=30)
+
+    try:
+        starttime = time.perf_counter()
+        changed = utils.get_changed_seeds(old, new)
+        diffs = IdentityProviders(memo['args'], memo['dry_run']).seed(changed)
+        duration = timedelta(seconds=time.perf_counter()-starttime)
+        utils.setStatusFields('identity_providers', patch, 'seeded', duration=duration, diffs=diffs)
+    except Exception as error:
+        utils.setStatusFields('identity_providers', patch, 'error', 0, latest_error=str(error))
+        raise kopf.TemporaryError('error seeding {}: {}'.format(name, error), delay=30)
+    finally:
+        patch.status['latest_reconcile'] = datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+class IdentityProviders():
+    def __init__(self, args, dry_run=False):
+        self.dry_run = dry_run
+        self.args = args
+        self.openstack = OpenstackHelper(args)
+        self.diffs = {}
+
+    def seed(self, identity_providers):
+        logging.info('seeding identity providers')
+        for idp in identity_providers:
+            self._seed_identity_provider(idp)
+        return self.diffs
+
+    def _seed_identity_provider(self, idp):
+        """Seed a Keystone identity provider with optional nested protocols."""
+        logging.debug("seeding identity provider %s" % idp.get('id'))
+
+        # Extract nested protocols before sanitizing the parent
+        protocols = idp.get('protocols', [])
+
+        idp_id = idp['id']
+        idp_data = self.openstack.sanitize(idp,
+                        ('description', 'enabled', 'remote_ids'))
+
+        keystone = self.openstack.get_keystoneclient()
+
+        try:
+            resource = keystone.federation.identity_providers.get(idp_id)
+            # IdP exists, check for differences
+            existing = {
+                'description': getattr(resource, 'description', ''),
+                'enabled': getattr(resource, 'enabled', True),
+                'remote_ids': getattr(resource, 'remote_ids', []),
+            }
+            diff = DeepDiff(existing, idp_data, threshold_to_diff_deeper=0)
+            if diff:
+                logging.info("update identity provider '%s': %s" % (idp_id, diff))
+                self.diffs[idp_id] = str(diff)
+                if not self.dry_run:
+                    keystone.federation.identity_providers.update(idp_id, **idp_data)
+        except Exception:
+            # IdP does not exist, create it
+            logging.info("create identity provider '%s'" % idp_id)
+            self.diffs[idp_id] = 'created'
+            if not self.dry_run:
+                keystone.federation.identity_providers.create(idp_id, **idp_data)
+
+        if protocols:
+            self._seed_protocols(idp_id, protocols)
+
+    def _seed_protocols(self, idp_id, protocols):
+        """Seed federation protocols for an identity provider."""
+        keystone = self.openstack.get_keystoneclient()
+
+        for protocol in protocols:
+            protocol_id = protocol['id']
+            mapping_id = protocol['mapping_id']
+
+            try:
+                resource = keystone.federation.protocols.get(idp_id, protocol_id)
+                # Protocol exists, check if mapping changed
+                if getattr(resource, 'mapping_id', '') != mapping_id:
+                    logging.info("update protocol '%s/%s' mapping to '%s'" % (
+                        idp_id, protocol_id, mapping_id))
+                    self.diffs['%s/%s' % (idp_id, protocol_id)] = 'mapping updated'
+                    if not self.dry_run:
+                        keystone.federation.protocols.update(
+                            idp_id, protocol_id, mapping_id)
+            except Exception:
+                # Protocol does not exist, create it
+                logging.info("create protocol '%s/%s' with mapping '%s'" % (
+                    idp_id, protocol_id, mapping_id))
+                self.diffs['%s/%s' % (idp_id, protocol_id)] = 'created'
+                if not self.dry_run:
+                    keystone.federation.protocols.create(
+                        protocol_id, idp_id, mapping_id)

--- a/seeder_ccloud/tests/seed_types/test_federation_mappings.py
+++ b/seeder_ccloud/tests/seed_types/test_federation_mappings.py
@@ -1,0 +1,124 @@
+"""
+ Copyright 2025 SAP SE
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import json, unittest, kopf
+from seeder_ccloud.openstack.openstack_helper import OpenstackHelper
+from seeder_ccloud.handlers.federation_mappings import FederationMappings, validate_federation_mappings
+from unittest.mock import Mock
+
+
+os = OpenstackHelper({})
+
+# Mapping rules are always a JSON string — never YAML, never a Python dict.
+RULES_JSON = '[{"local": [{"user": {"name": "{0}", "domain": {"name": "test-domain"}}}], "remote": [{"type": "REMOTE_USER"}]}]'
+RULES_JSON_UPDATED = '[{"local": [{"user": {"name": "{0}", "domain": {"name": "test-domain-updated"}}}], "remote": [{"type": "REMOTE_USER"}]}]'
+
+# The parsed form is what keystoneclient expects (Python list).
+RULES_PARSED = json.loads(RULES_JSON)
+RULES_PARSED_UPDATED = json.loads(RULES_JSON_UPDATED)
+
+
+class TestFederationMappings(unittest.TestCase):
+
+    def _make_mock(self):
+        """Build a mock keystone client with federation.mappings."""
+        mock_keystone = Mock()
+        mock_openstack = Mock()
+        mock_openstack.get_keystoneclient.return_value = mock_keystone
+        mock_openstack.sanitize = os.sanitize
+        return mock_openstack, mock_keystone
+
+    def test_mapping_create(self):
+        mock_openstack, mock_keystone = self._make_mock()
+        mock_keystone.federation.mappings.get.side_effect = Exception("not found")
+        handler = FederationMappings({}, dry_run=False)
+        handler.openstack = mock_openstack
+        handler.seed([{'id': 'test-mapping', 'schema_version': '2.0', 'rules': RULES_JSON}])
+        # keystoneclient receives a Python list, not a JSON string
+        mock_keystone.federation.mappings.create.assert_called_with(
+            'test-mapping', rules=RULES_PARSED, schema_version='2.0')
+
+    def test_mapping_dry_run(self):
+        mock_openstack, mock_keystone = self._make_mock()
+        mock_keystone.federation.mappings.get.side_effect = Exception("not found")
+        handler = FederationMappings({}, dry_run=True)
+        handler.openstack = mock_openstack
+        handler.seed([{'id': 'test-mapping', 'schema_version': '2.0', 'rules': RULES_JSON}])
+        assert not mock_keystone.federation.mappings.create.called
+
+    def test_mapping_update(self):
+        mock_openstack, mock_keystone = self._make_mock()
+        existing = Mock()
+        existing.rules = RULES_PARSED
+        existing.schema_version = '2.0'
+        mock_keystone.federation.mappings.get.return_value = existing
+        handler = FederationMappings({}, dry_run=False)
+        handler.openstack = mock_openstack
+        handler.seed([{'id': 'test-mapping', 'schema_version': '2.0', 'rules': RULES_JSON_UPDATED}])
+        mock_keystone.federation.mappings.update.assert_called_with(
+            'test-mapping', rules=RULES_PARSED_UPDATED, schema_version='2.0')
+
+    def test_mapping_no_update_when_unchanged(self):
+        mock_openstack, mock_keystone = self._make_mock()
+        existing = Mock()
+        existing.rules = RULES_PARSED
+        existing.schema_version = '2.0'
+        mock_keystone.federation.mappings.get.return_value = existing
+        handler = FederationMappings({}, dry_run=False)
+        handler.openstack = mock_openstack
+        handler.seed([{'id': 'test-mapping', 'schema_version': '2.0', 'rules': RULES_JSON}])
+        assert not mock_keystone.federation.mappings.update.called
+
+
+class TestFederationMappingValidation(unittest.TestCase):
+
+    def test_validate_missing_id(self):
+        spec = {'federation_mappings': [{'rules': RULES_JSON}]}
+        self.assertRaisesRegex(
+            kopf.AdmissionError,
+            'must have an id',
+            validate_federation_mappings, spec, False)
+
+    def test_validate_missing_rules(self):
+        spec = {'federation_mappings': [{'id': 'test-mapping'}]}
+        self.assertRaisesRegex(
+            kopf.AdmissionError,
+            'must have rules',
+            validate_federation_mappings, spec, False)
+
+    def test_validate_invalid_json(self):
+        spec = {'federation_mappings': [{'id': 'test-mapping', 'rules': 'not valid json'}]}
+        self.assertRaisesRegex(
+            kopf.AdmissionError,
+            'valid JSON',
+            validate_federation_mappings, spec, False)
+
+    def test_validate_not_a_json_array(self):
+        spec = {'federation_mappings': [{'id': 'test-mapping', 'rules': '{"not": "an array"}'}]}
+        self.assertRaisesRegex(
+            kopf.AdmissionError,
+            'JSON array',
+            validate_federation_mappings, spec, False)
+
+    def test_validate_valid(self):
+        spec = {'federation_mappings': [{
+            'id': 'test-mapping',
+            'rules': RULES_JSON,
+        }]}
+        try:
+            validate_federation_mappings(spec, False)
+        except kopf.AdmissionError:
+            self.fail("validate_federation_mappings raised AdmissionError on valid input")

--- a/seeder_ccloud/tests/seed_types/test_identity_providers.py
+++ b/seeder_ccloud/tests/seed_types/test_identity_providers.py
@@ -1,0 +1,205 @@
+"""
+ Copyright 2025 SAP SE
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import unittest, kopf
+from seeder_ccloud.openstack.openstack_helper import OpenstackHelper
+from seeder_ccloud.handlers.identity_providers import IdentityProviders, validate_identity_providers
+from unittest.mock import patch, Mock
+
+
+os = OpenstackHelper({})
+
+class TestIdentityProviders(unittest.TestCase):
+
+    def _make_mock(self):
+        """Build a mock keystone client with federation.identity_providers and federation.protocols."""
+        mock_keystone = Mock()
+        mock_openstack = Mock()
+        mock_openstack.get_keystoneclient.return_value = mock_keystone
+        mock_openstack.sanitize = os.sanitize
+        return mock_openstack, mock_keystone
+
+    def test_idp_create(self):
+        mock_openstack, mock_keystone = self._make_mock()
+        mock_keystone.federation.identity_providers.get.side_effect = Exception("not found")
+        handler = IdentityProviders({}, dry_run=False)
+        handler.openstack = mock_openstack
+        handler.seed([{
+            'id': 'test-idp',
+            'description': 'Test IdP',
+            'enabled': True,
+            'remote_ids': ['https://idp.example.com/metadata'],
+        }])
+        mock_keystone.federation.identity_providers.create.assert_called_with(
+            'test-idp',
+            description='Test IdP',
+            enabled=True,
+            remote_ids=['https://idp.example.com/metadata'],
+        )
+
+    def test_idp_dry_run(self):
+        mock_openstack, mock_keystone = self._make_mock()
+        mock_keystone.federation.identity_providers.get.side_effect = Exception("not found")
+        handler = IdentityProviders({}, dry_run=True)
+        handler.openstack = mock_openstack
+        handler.seed([{
+            'id': 'test-idp',
+            'description': 'Test IdP',
+            'enabled': True,
+            'remote_ids': ['https://idp.example.com/metadata'],
+        }])
+        assert not mock_keystone.federation.identity_providers.create.called
+
+    def test_idp_update(self):
+        mock_openstack, mock_keystone = self._make_mock()
+        existing = Mock()
+        existing.description = 'Old description'
+        existing.enabled = True
+        existing.remote_ids = ['https://idp.example.com/metadata']
+        mock_keystone.federation.identity_providers.get.return_value = existing
+        handler = IdentityProviders({}, dry_run=False)
+        handler.openstack = mock_openstack
+        handler.seed([{
+            'id': 'test-idp',
+            'description': 'New description',
+            'enabled': True,
+            'remote_ids': ['https://idp.example.com/metadata'],
+        }])
+        mock_keystone.federation.identity_providers.update.assert_called_once()
+
+    def test_idp_no_update_when_unchanged(self):
+        mock_openstack, mock_keystone = self._make_mock()
+        existing = Mock()
+        existing.description = 'Same description'
+        existing.enabled = True
+        existing.remote_ids = ['https://idp.example.com/metadata']
+        mock_keystone.federation.identity_providers.get.return_value = existing
+        handler = IdentityProviders({}, dry_run=False)
+        handler.openstack = mock_openstack
+        handler.seed([{
+            'id': 'test-idp',
+            'description': 'Same description',
+            'enabled': True,
+            'remote_ids': ['https://idp.example.com/metadata'],
+        }])
+        assert not mock_keystone.federation.identity_providers.update.called
+
+    def test_protocol_create(self):
+        mock_openstack, mock_keystone = self._make_mock()
+        # IdP exists
+        existing_idp = Mock()
+        existing_idp.description = 'Test'
+        existing_idp.enabled = True
+        existing_idp.remote_ids = ['https://idp.example.com/metadata']
+        mock_keystone.federation.identity_providers.get.return_value = existing_idp
+        # Protocol does not exist
+        mock_keystone.federation.protocols.get.side_effect = Exception("not found")
+        handler = IdentityProviders({}, dry_run=False)
+        handler.openstack = mock_openstack
+        handler.seed([{
+            'id': 'test-idp',
+            'description': 'Test',
+            'enabled': True,
+            'remote_ids': ['https://idp.example.com/metadata'],
+            'protocols': [{'id': 'saml2', 'mapping_id': 'test-mapping'}],
+        }])
+        mock_keystone.federation.protocols.create.assert_called_with(
+            'saml2', 'test-idp', 'test-mapping')
+
+    def test_protocol_update(self):
+        mock_openstack, mock_keystone = self._make_mock()
+        # IdP exists
+        existing_idp = Mock()
+        existing_idp.description = 'Test'
+        existing_idp.enabled = True
+        existing_idp.remote_ids = ['https://idp.example.com/metadata']
+        mock_keystone.federation.identity_providers.get.return_value = existing_idp
+        # Protocol exists with different mapping
+        existing_protocol = Mock()
+        existing_protocol.mapping_id = 'old-mapping'
+        mock_keystone.federation.protocols.get.return_value = existing_protocol
+        handler = IdentityProviders({}, dry_run=False)
+        handler.openstack = mock_openstack
+        handler.seed([{
+            'id': 'test-idp',
+            'description': 'Test',
+            'enabled': True,
+            'remote_ids': ['https://idp.example.com/metadata'],
+            'protocols': [{'id': 'saml2', 'mapping_id': 'new-mapping'}],
+        }])
+        mock_keystone.federation.protocols.update.assert_called_with(
+            'test-idp', 'saml2', 'new-mapping')
+
+    def test_protocol_no_update_when_unchanged(self):
+        mock_openstack, mock_keystone = self._make_mock()
+        existing_idp = Mock()
+        existing_idp.description = 'Test'
+        existing_idp.enabled = True
+        existing_idp.remote_ids = ['https://idp.example.com/metadata']
+        mock_keystone.federation.identity_providers.get.return_value = existing_idp
+        existing_protocol = Mock()
+        existing_protocol.mapping_id = 'test-mapping'
+        mock_keystone.federation.protocols.get.return_value = existing_protocol
+        handler = IdentityProviders({}, dry_run=False)
+        handler.openstack = mock_openstack
+        handler.seed([{
+            'id': 'test-idp',
+            'description': 'Test',
+            'enabled': True,
+            'remote_ids': ['https://idp.example.com/metadata'],
+            'protocols': [{'id': 'saml2', 'mapping_id': 'test-mapping'}],
+        }])
+        assert not mock_keystone.federation.protocols.update.called
+
+
+class TestIdentityProviderValidation(unittest.TestCase):
+
+    def test_validate_missing_id(self):
+        spec = {'identity_providers': [{'description': 'no id'}]}
+        self.assertRaisesRegex(
+            kopf.AdmissionError,
+            'must have an id',
+            validate_identity_providers, spec, False)
+
+    def test_validate_missing_protocol_id(self):
+        spec = {'identity_providers': [{
+            'id': 'test-idp',
+            'protocols': [{'mapping_id': 'test-mapping'}],
+        }]}
+        self.assertRaisesRegex(
+            kopf.AdmissionError,
+            'Protocol must have an id',
+            validate_identity_providers, spec, False)
+
+    def test_validate_missing_protocol_mapping_id(self):
+        spec = {'identity_providers': [{
+            'id': 'test-idp',
+            'protocols': [{'id': 'saml2'}],
+        }]}
+        self.assertRaisesRegex(
+            kopf.AdmissionError,
+            'must have a mapping_id',
+            validate_identity_providers, spec, False)
+
+    def test_validate_valid(self):
+        spec = {'identity_providers': [{
+            'id': 'test-idp',
+            'protocols': [{'id': 'saml2', 'mapping_id': 'test-mapping'}],
+        }]}
+        try:
+            validate_identity_providers(spec, False)
+        except kopf.AdmissionError:
+            self.fail("validate_identity_providers raised AdmissionError on valid input")


### PR DESCRIPTION
New handlers for Keystone OS-FEDERATION resources:
- identity_providers.py: creates/updates IdPs with remote_ids, nests protocol seeding (following the services.py -> endpoints pattern)
- federation_mappings.py: creates/updates federation mappings with rules

Both use python-keystoneclient's federation API which is already a dependency. Handlers are registered in the chart config.yaml.

Also adds handlers list to etc/config.ini (needed for test imports and local development).