### PR TITLE
add helper file for ClusterDnsSearchDomain

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -3,4 +3,4 @@
 Construct the Keystone authentication URL base.
 Uses global.clusterDomain if set, otherwise falls back to global.clusterDNSSearchDomain.
 */}}
-{{define "keystone_url"}}http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{ if .Values.global.clusterDomain }}{{.Values.global.clusterDomain}}{{ else }}{{.Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain"}}{{end}}:5000{{end}}
+{{define "keystone_url"}}http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{ if .Values.global.clusterDomain }}{{.Values.global.clusterDomain}}{{ else }}{{.Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain"}}{{end}}:5000/v3{{end}}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,12 +1,6 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Construct the Keystone authentication URL.
+Construct the Keystone authentication URL base.
 Uses global.clusterDomain if set, otherwise falls back to global.clusterDNSSearchDomain.
 */}}
-{{- define "ccloud-seeder.keystone_url" -}}
-{{- if .Values.global.clusterDomain -}}
-http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{ .Values.global.clusterDomain }}:5000
-{{- else -}}
-http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{ .Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain" }}:5000
-{{- end -}}
-{{- end -}}
+{{define "keystone_url"}}{{ if .Values.global.clusterDomain }}http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{.Values.global.clusterDomain}}:5000{{ else }}http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{.Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain"}}:5000{{end}}{{end}}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -3,4 +3,4 @@
 Construct the Keystone authentication URL base.
 Uses global.clusterDomain if set, otherwise falls back to global.clusterDNSSearchDomain.
 */}}
-{{define "keystone_url"}}{{ if .Values.global.clusterDomain }}http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{.Values.global.clusterDomain}}:5000{{ else }}http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{.Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain"}}:5000{{end}}{{end}}
+{{define "keystone_url"}}http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{ if .Values.global.clusterDomain }}{{.Values.global.clusterDomain}}{{ else }}{{.Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain"}}{{end}}:5000{{end}}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Construct the Keystone authentication URL.
+Uses global.clusterDomain if set, otherwise falls back to global.clusterDNSSearchDomain.
+*/}}
+{{- define "ccloud-seeder.keystone_url" -}}
+{{- if .Values.global.clusterDomain -}}
+http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{ .Values.global.clusterDomain }}:5000
+{{- else -}}
+http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{ .Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain" }}:5000
+{{- end -}}
+{{- end -}}

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -4,11 +4,7 @@ type: Opaque
 metadata:
   name: ccloud-seeder
 data:
-  {{- if .Values.keystone.authUrl }}
-  OS_AUTH_URL: {{ .Values.keystone.authUrl | b64enc | quote }}
-  {{- else }}
-  OS_AUTH_URL: {{ printf "%s/v3" (include "keystone_url" .) | b64enc | quote }}
-  {{- end }}
+  OS_AUTH_URL: {{ .Values.keystone.authUrl | default (include "keystone_url" .) | b64enc | quote }}
   OS_USERNAME: {{ required ".Values.keystone.username undefined" .Values.keystone.username | b64enc | quote }}
   OS_PASSWORD: {{ required ".Values.keystone.password undefined" .Values.keystone.password | b64enc | quote }}
   OS_USER_DOMAIN_ID: {{ required ".Values.keystone.userDomainId undefined" .Values.keystone.userDomainId | b64enc | quote }}

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -4,7 +4,11 @@ type: Opaque
 metadata:
   name: ccloud-seeder
 data:
-  OS_AUTH_URL: {{ required ".Values.keystone.authUrl undefined" .Values.keystone.authUrl | b64enc | quote }}
+  {{- if .Values.keystone.authUrl }}
+  OS_AUTH_URL: {{ .Values.keystone.authUrl | b64enc | quote }}
+  {{- else }}
+  OS_AUTH_URL: {{ printf "%s/v3" (include "keystone_url" .) | b64enc | quote }}
+  {{- end }}
   OS_USERNAME: {{ required ".Values.keystone.username undefined" .Values.keystone.username | b64enc | quote }}
   OS_PASSWORD: {{ required ".Values.keystone.password undefined" .Values.keystone.password | b64enc | quote }}
   OS_USER_DOMAIN_ID: {{ required ".Values.keystone.userDomainId undefined" .Values.keystone.userDomainId | b64enc | quote }}


### PR DESCRIPTION
Add helper file for eu-de-3 region,domain-seeds not working with error: `Failed to resolve 'keystone.monsoon3.svc.kubernetes.eu-de-3.cloud.sap' `because of the new variable `.Values.global.clusterDNSSearchDomain`
  
Builds a Keystone service URL with this logic:
    - If global.clusterDomain is set: uses that                                                                         
    - Otherwise: falls back to global.clusterDNSSearchDomain (and requires it to be set)   